### PR TITLE
Added a Vary: Accept-Response header to prevent caches from incorrectly storing redirects

### DIFF
--- a/lib/rack/locale_root_redirect/middleware.rb
+++ b/lib/rack/locale_root_redirect/middleware.rb
@@ -22,6 +22,7 @@ module Rack
 
         status = STATUS
         query_string = env['QUERY_STRING'] == '' ? '' : "?#{env['QUERY_STRING']}"
+        headers['Vary'] = 'Accept-Language'
         headers['Location'] = @locales[locale.to_sym] + query_string
       end
 

--- a/spec/rack/locale_root_redirect_spec.rb
+++ b/spec/rack/locale_root_redirect_spec.rb
@@ -14,16 +14,19 @@ describe Rack::LocaleRootRedirect do
       context 'with first matching language' do
         let(:accept_language) { %w{en es;q=0.9} }
         it { expect(response.headers['Location']).to eq '/en?foo=bar' }
+        it { expect(response.headers['Vary']).to eq 'Accept-Language'}
       end
 
       context 'with second matching language' do
         let(:accept_language) { %w{es en;q=0.8} }
         it { expect(response.headers['Location']).to eq '/en?foo=bar' }
+        it { expect(response.headers['Vary']).to eq 'Accept-Language'}
       end
 
       context 'with default matching language' do
         let(:accept_language) { %w{es jp;q=0.8} }
         it { expect(response.headers['Location']).to eq '/fr?foo=bar' }
+        it { expect(response.headers['Vary']).to eq 'Accept-Language'}
       end
     end
   end


### PR DESCRIPTION
To prevent caches from incorrectly caching the redirect when users have different Accept-Language requests, a vary header should be sent along with the redirect.

See http://tools.ietf.org/html/rfc7231#section-7.1.4 for further information.