### PR TITLE
Do not alter the response if it’s already being redirected

### DIFF
--- a/spec/rack/locale_root_redirect_spec.rb
+++ b/spec/rack/locale_root_redirect_spec.rb
@@ -1,38 +1,50 @@
 require 'spec_helper'
 
 describe Rack::LocaleRootRedirect do
-  let(:app) { proc { [200, {}, ['Hello, world.']] } }
   let(:request) { Rack::MockRequest.new(stack) }
+  let(:locales) { { fr: '/fr', en: '/en' } }
 
   context 'with stack using Rack::Accept' do
     let(:stack) { Rack::LocaleRootRedirect.new(Rack::Accept.new(app), locales) }
+    let(:response) { request.get('/?foo=bar', 'HTTP_ACCEPT_LANGUAGE' => accept_language.join(',')) }
 
-    describe 'response' do
-      let(:locales) { { fr: '/fr', en: '/en' } }
-      let(:response) { request.get('/?foo=bar', 'HTTP_ACCEPT_LANGUAGE' => accept_language.join(',')) }
+    context 'with response already being redirected' do
+      let(:app) { proc { [301, { 'Location' => '/new-place' }, ['You are being redirected...']] } }
 
-      context 'with first matching language' do
-        let(:accept_language) { %w(en es;q=0.9) }
-        it { expect(response.headers['Location']).to eq '/en?foo=bar' }
-        it { expect(response.headers['Vary']).to eq 'Accept-Language' }
+      describe 'response headers' do
+        let(:accept_language) { %w() }
+        it { expect(response.headers['Location']).to eq '/new-place' }
+        it { expect(response.headers['Vary']).to be_nil }
       end
+    end
 
-      context 'with second matching language' do
-        let(:accept_language) { %w(es en;q=0.8) }
-        it { expect(response.headers['Location']).to eq '/en?foo=bar' }
-        it { expect(response.headers['Vary']).to eq 'Accept-Language' }
-      end
+    context 'with response not already being redirected' do
+      let(:app) { proc { [200, {}, ['Hello, world.']] } }
 
-      context 'with default matching language' do
-        let(:accept_language) { %w(es jp;q=0.8) }
-        it { expect(response.headers['Location']).to eq '/fr?foo=bar' }
-        it { expect(response.headers['Vary']).to eq 'Accept-Language' }
+      describe 'response headers' do
+        context 'with first matching language' do
+          let(:accept_language) { %w(en es;q=0.9) }
+          it { expect(response.headers['Location']).to eq '/en?foo=bar' }
+          it { expect(response.headers['Vary']).to eq 'Accept-Language' }
+        end
+
+        context 'with second matching language' do
+          let(:accept_language) { %w(es en;q=0.8) }
+          it { expect(response.headers['Location']).to eq '/en?foo=bar' }
+          it { expect(response.headers['Vary']).to eq 'Accept-Language' }
+        end
+
+        context 'with default matching language' do
+          let(:accept_language) { %w(es jp;q=0.8) }
+          it { expect(response.headers['Location']).to eq '/fr?foo=bar' }
+          it { expect(response.headers['Vary']).to eq 'Accept-Language' }
+        end
       end
     end
   end
 
   context 'with stack without Rack::Accept' do
-    let(:locales) { { fr: '/fr', en: '/en' } }
+    let(:app) { proc { [200, {}, ['Hello, world.']] } }
     let(:stack) { Rack::LocaleRootRedirect.new(app, locales) }
 
     specify do


### PR DESCRIPTION
For some reason, if the `Rack` application decides to redirect the response before `Rack::LocaleRootRedirect` is called, we shouldn’t get in the way.

If the response’s status is `3XX`, we refrain from touching it.